### PR TITLE
Allow apps to handle the Android "back" button.

### DIFF
--- a/app/queue.go
+++ b/app/queue.go
@@ -69,6 +69,15 @@ func handleEvents(queue *android.InputQueue, evHandler func(ev *android.InputEve
 			continue
 		}
 		evHandler(ev)
-		android.InputQueueFinishEvent(queue, ev, 0)
+		var response int32 = 0
+
+		switch android.InputEventGetType(ev) {
+		case android.InputEventTypeKey:
+			key := android.KeyEventGetKeyCode(ev)
+			if key == android.KeycodeBack {
+				response = 1
+			}
+		}
+		android.InputQueueFinishEvent(queue, ev, response)
 	}
 }


### PR DESCRIPTION
Rough patch to allow apps to handle the "back" button without Android closing the app. This should be user-configurable but not sure on how you would like to implement this as app/handleEvents() does not keep a pointer to the nativeActivity struct where this configuration would logically be maintained.