### PR TITLE
fix force parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+*.iml

--- a/cmd/android-project/README.md
+++ b/cmd/android-project/README.md
@@ -7,7 +7,7 @@ I used `android project update` to simply create Ant build scripts for the proje
 ### Installation
 
 ```
-go get github.com/xlab/android-go/cmd/android-project
+go install github.com/xlab/android-go/cmd/android-project@latest
 ```
 
 Also you must set `$ANDROID_HOME` to your Android SDK location, e.g.
@@ -19,7 +19,7 @@ export ANDROID_HOME=/Users/xlab/Library/Android/sdk
 ### Usage
 
 ```
-Usage: android-project update [--sdk] [--target] --name --path
+Usage: android-project update [--sdk] [--target] [--force] --name --path
 
 Updates an Android project (must already have an AndroidManifest.xml)
 ```

--- a/cmd/android-project/main.go
+++ b/cmd/android-project/main.go
@@ -60,7 +60,7 @@ func cmdUpdateFunc(c *cli.Cmd) {
 		EnvVar:    "ANDROID_HOME",
 		HideValue: true,
 	})
-	c.Spec = "[--sdk] [--target] --name --path"
+	c.Spec = "[--sdk] [--target] [--force] --name --path"
 	c.Action = func() {
 		defer closer.Close()
 


### PR DESCRIPTION
Fixed --force switch.
The routine for detecting supported APIs by SDK does not work, so it is needed to use the --force switch.
"c.Spec" validates input ... it is why the switch didn't work.