### PR TITLE
replace ALooper_pollAll (removed in API 34)

### DIFF
--- a/android/android.go
+++ b/android/android.go
@@ -590,7 +590,7 @@ func LooperPollAll(timeoutMillis int32, outFd *int32, outEvents *int32, outData 
 	coutFd, _ := (*C.int)(unsafe.Pointer(outFd)), cgoAllocsUnknown
 	coutEvents, _ := (*C.int)(unsafe.Pointer(outEvents)), cgoAllocsUnknown
 	coutData, _ := (*unsafe.Pointer)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&outData)).Data)), cgoAllocsUnknown
-	__ret := C.ALooper_pollAll(ctimeoutMillis, coutFd, coutEvents, coutData)
+	__ret := C.ALooper_pollOnce(ctimeoutMillis, coutFd, coutEvents, coutData)
 	__v := (int32)(__ret)
 	return __v
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/xlab/android-go
 
-go 1.16
+go 1.20


### PR DESCRIPTION
The new NDK does not want to compile because of the usage of `ALooper_pollAll`.
The recommended action is to replace with `ALooper_pollOnce`.